### PR TITLE
[FIX] Fixing name on sign-up bug

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 end


### PR DESCRIPTION
When testing the app we found that the user name was not recognise even though a valid one was entered.

After reading previous commits we found an important part of the code was erased.

We added the missing code and the bug was fixed.

PT Entry: https://www.pivotaltracker.com/n/projects/2360713/stories/167064425